### PR TITLE
Refactor disposable email blocklist functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-export const disposableEmailBlocklist = async (): Promise<string[]> => {
-  return await require('./dict/disposable_email_blocklist.json');
+export const disposableEmailBlocklist = (): string[] => {
+  return require('./dict/disposable_email_blocklist.json');
 };
 
-export const isDisposableEmail = async (email: string): Promise<boolean> => {
-  const blocklist = await disposableEmailBlocklist();
+export const isDisposableEmail = (email: string): boolean => {
+  const blocklist = disposableEmailBlocklist();
   const domain = email.split('@').reverse()[0];
 
   return blocklist.includes(domain);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,22 +1,22 @@
 import { disposableEmailBlocklist, isDisposableEmail } from '../src/index';
 
 describe('disposableEmailBlocklist', () => {
-  test('should return an array of strings', async () => {
-    const result = await disposableEmailBlocklist();
+  test('should return an array of strings', () => {
+    const result = disposableEmailBlocklist();
 
     expect(result).not.toEqual([]);
   });
 });
 
 describe('isDisposableEmail', () => {
-  test('should return false for disposable email', async () => {
-    const result = await isDisposableEmail('example@example.com');
+  test('should return false for disposable email', () => {
+    const result = isDisposableEmail('example@example.com');
 
     expect(result).toBe(false);
   });
 
-  test('should return true for disposable email', async () => {
-    const result = await isDisposableEmail('example@zzz.com');
+  test('should return true for disposable email', () => {
+    const result = isDisposableEmail('example@zzz.com');
 
     expect(result).toBe(true);
   });


### PR DESCRIPTION
This pull request refactors the disposable email blocklist functions in the codebase. The `disposableEmailBlocklist` function is modified to return a string array directly, without the need for an async operation. Similarly, the `isDisposableEmail` function is modified to directly use the blocklist without an async operation. The corresponding test cases are also updated to reflect these changes.