### PR TITLE
Add update domain list workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 on:
   push:

--- a/.github/workflows/update_domein_list.yml
+++ b/.github/workflows/update_domein_list.yml
@@ -1,0 +1,39 @@
+name: Update Domain List
+
+on:
+  schedule:
+    - cron: '*/20 * * * *'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/update_domein_list.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_domain_list:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - run: npm install
+      - run: npm run generate:disposable_email_blocklist_json
+      - run: npm run lint:fix
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update domain list
+          delete-branch: true
+          title: Update domain list
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          reviewers: mziyut
+          branch: create-pull-request/patch-pull-articles


### PR DESCRIPTION
This pull request adds a new workflow called "Update Domain List". The workflow is triggered on a schedule and when changes are pushed to the `.github/workflows/update_domein_list.yml` file. It runs on the latest Ubuntu environment and performs the following steps:

- Checks out the code using `actions/checkout@v4`

- Sets up Node.js using `actions/setup-node@v4`

- Installs dependencies using `npm install`

- Generates a disposable email blocklist JSON using `npm run generate:disposable_email_blocklist_json`

- Fixes linting issues using `npm run lint:fix`