### PR TITLE
Remove whitespace and convert the domain to lowercase before check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ export const disposableEmailBlocklist = (): string[] => {
 export const isDisposableEmailDomain = (domain: string): boolean => {
   const blocklist = disposableEmailBlocklist();
 
-  return blocklist.includes(domain);
+  const normalisedDomain = domain.trim().toLowerCase();
+
+  return blocklist.includes(normalisedDomain);
 };
 
 export const isDisposableEmail = (email: string): boolean => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,7 +6,7 @@ describe('disposableEmailBlocklist', () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeGreaterThan(0);
-    expect(result.every(value => typeof value === 'string')).toBe(true);
+    expect(result.every((value) => typeof value === 'string')).toBe(true);
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,12 +4,14 @@ describe('disposableEmailBlocklist', () => {
   test('should return an array of strings', () => {
     const result = disposableEmailBlocklist();
 
-    expect(result).not.toEqual([]);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every(value => typeof value === 'string')).toBe(true);
   });
 });
 
 describe('isDisposableEmailDomain', () => {
-  test('should return false for disposable domain', () => {
+  test('should return false for non-disposable domain', () => {
     const result = isDisposableEmail('example.com');
 
     expect(result).toBe(false);
@@ -20,10 +22,46 @@ describe('isDisposableEmailDomain', () => {
 
     expect(result).toBe(true);
   });
+
+  test('should return false for non-disposable domain with capitalisation', () => {
+    const result = isDisposableEmail('example.com');
+
+    expect(result).toBe(false);
+  });
+
+  test('should return true for disposable domain with capitalisation', () => {
+    const result = isDisposableEmail('Mailinator.com');
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for non-disposable domain with leading whitespace', () => {
+    const result = isDisposableEmail(' example.com');
+
+    expect(result).toBe(false);
+  });
+
+  test('should return true for disposable domain with leading whitespace', () => {
+    const result = isDisposableEmail(' mailinator.com');
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for non-disposable domain with trailing whitespace', () => {
+    const result = isDisposableEmail('example.com ');
+
+    expect(result).toBe(false);
+  });
+
+  test('should return true for disposable domain with trailing whitespace', () => {
+    const result = isDisposableEmail('mailinator.com ');
+
+    expect(result).toBe(true);
+  });
 });
 
 describe('isDisposableEmail', () => {
-  test('should return false for disposable email', () => {
+  test('should return false for non-disposable email', () => {
     const result = isDisposableEmail('example@example.com');
 
     expect(result).toBe(false);
@@ -31,6 +69,42 @@ describe('isDisposableEmail', () => {
 
   test('should return true for disposable email', () => {
     const result = isDisposableEmail('example@zzz.com');
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for non-disposable email with capitalisation', () => {
+    const result = isDisposableEmail('Example@Example.com');
+
+    expect(result).toBe(false);
+  });
+
+  test('should return true for disposable email with capitalisation', () => {
+    const result = isDisposableEmail('Example@zZZ.com');
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for non-disposable email with leading whitespace', () => {
+    const result = isDisposableEmail('example@ example.com');
+
+    expect(result).toBe(false);
+  });
+
+  test('should return true for disposable email with leading whitespace', () => {
+    const result = isDisposableEmail('example@ zzz.com');
+
+    expect(result).toBe(true);
+  });
+
+  test('should return false for non-disposable email with trailing whitespace', () => {
+    const result = isDisposableEmail('example@example.com ');
+
+    expect(result).toBe(false);
+  });
+
+  test('should return true for disposable email with trailing whitespace', () => {
+    const result = isDisposableEmail('example@zzz.com ');
 
     expect(result).toBe(true);
   });


### PR DESCRIPTION
Hello,

Thank you for making this dataset into an NPM library!

I thought that the check for disposable domains might be made more robust by adding the following preprocessing steps:

1. Remove leading/trailing whitespace.
2. Convert the domain to lowercase.

This would help anyone that is passing raw user input into the function.

Thanks,
~ Paddy
