### PR TITLE
Update disposable_email_blocklist.json

### DIFF
--- a/src/dict/disposable_email_blocklist.json
+++ b/src/dict/disposable_email_blocklist.json
@@ -1343,6 +1343,7 @@
   "freeteenbums.com",
   "freundin.ru",
   "friendlymail.co.uk",
+  "frisbook.com",
   "front14.org",
   "frwdmail.com",
   "ftp.sh",


### PR DESCRIPTION
Update disposable_email_blocklist.json with frisbook.com.

https://verifymail.io/domain/frisbook.com
