### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Publish Package to npmjs
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/mziyut/disposable-email-domains-js/security/code-scanning/2](https://github.com/mziyut/disposable-email-domains-js/security/code-scanning/2)

To address the issue, explicitly define the `permissions` key at the workflow level. This ensures that the `GITHUB_TOKEN` is limited to the least privileges required for the workflow to complete its tasks. For this workflow, publishing to npm likely requires `contents: read` to access repository files and potentially `packages: write` to publish packages. Therefore:
1. Add the `permissions` block at the root level of the workflow.
2. Set permissions to `contents: read` and `packages: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
