### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   push:
 
+permissions:
+  contents: read
 jobs:
   test_jest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mziyut/disposable-email-domains-js/security/code-scanning/6](https://github.com/mziyut/disposable-email-domains-js/security/code-scanning/6)

The best way to fix the issue is to add a `permissions` block to the root of the workflow (to apply permissions globally) or to each individual job. In this case, adding permissions to the root of the workflow is more efficient, as most jobs require similar minimal permissions.

Steps to fix:
1. Add a `permissions` block at the root of the workflow file, specifying the least privileges required for the workflow.
2. Use `contents: read` as a baseline, as all jobs need to check out code from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
