### PR TITLE
Update usage examples to include isDisposableEmailDomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ disposableEmailDomains.isDisposableEmail('example@mailinator.com'); // return tr
 ```
 
 ```js
-import { isDisposableEmail } from 'disposable-email-domains-js';
+import {
+  isDisposableEmail,
+  isDisposableEmailDomain,
+} from 'disposable-email-domains-js';
 
 isDisposableEmailDomain('example.com'); // return false
 isDisposableEmail('example@example.com'); // return false


### PR DESCRIPTION
Enhance the README to demonstrate the usage of the `isDisposableEmailDomain` function alongside `isDisposableEmail`.