### PR TITLE
Add prettier-plugin-organize-imports and improve import organization

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,3 @@
-{}
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/bin/generate_disposable_email_blocklist.ts
+++ b/bin/generate_disposable_email_blocklist.ts
@@ -1,5 +1,4 @@
-import { readFile } from 'node:fs/promises';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 const disposableEmailBlocklist = async (): Promise<string[]> => {
   const content = await readFile(

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,7 +1,7 @@
 import {
   disposableEmailBlocklist,
-  isDisposableEmailDomain,
   isDisposableEmail,
+  isDisposableEmailDomain,
 } from 'disposable-email-domains-js';
 
 const filename = 'example.ts';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "jest-junit": "^16.0.0",
         "npm-run-all": "^4.1.5",
         "prettier": "3.6.2",
+        "prettier-plugin-organize-imports": "^4.2.0",
         "ts-jest": "^29.2.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.4"
@@ -4821,6 +4822,23 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.2.0.tgz",
+      "integrity": "sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jest-junit": "^16.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "3.6.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "ts-jest": "^29.2.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"


### PR DESCRIPTION
Introduce a new Prettier plugin for better import organization, consolidate import statements in the email blocklist file, and reorder imports in the example file for consistency.