### PR TITLE
Add npm audit job to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,22 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        node: [18, 20, 22, 24]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - run: npm ci
+      - name: Run npm audit
+        run: npm audit --production --audit-level=moderate
+        env:
+          CI: true


### PR DESCRIPTION
Introduce a new job in the CI workflow to run npm audit for security checks, ensuring dependencies meet the specified audit level.