### PR TITLE
Fix release workflow by removing global npm install command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,5 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by removing the global installation of the latest npm version. The workflow now uses the default npm version provided by the Node.js setup.